### PR TITLE
Remove spurious object subclassing

### DIFF
--- a/jenkins_job_linter/linters.py
+++ b/jenkins_job_linter/linters.py
@@ -20,7 +20,7 @@ from xml.etree import ElementTree
 from stevedore.extension import ExtensionManager
 
 
-class Linter(object):
+class Linter:
     """A super-class capturing the common linting pattern."""
 
     def __init__(self, tree: ElementTree.ElementTree,

--- a/tests/test_jenkins_job_linter.py
+++ b/tests/test_jenkins_job_linter.py
@@ -19,7 +19,7 @@ from click.testing import CliRunner
 from jenkins_job_linter import lint_job_xml, lint_jobs_from_directory, main
 
 
-class TestLintJobXML(object):
+class TestLintJobXML:
 
     def test_all_linters_called_with_tree_and_config(self, mocker):
         linter_mocks = [mocker.Mock() for _ in range(3)]
@@ -47,7 +47,7 @@ class TestLintJobXML(object):
                             mocker.MagicMock()) is expected
 
 
-class TestLintJobsFromDirectory(object):
+class TestLintJobsFromDirectory:
 
     def test_empty_directory(self, mocker):
         listdir_mock = mocker.patch('jenkins_job_linter.os.listdir')
@@ -87,7 +87,7 @@ class TestLintJobsFromDirectory(object):
             [call_args[0][0] for call_args in et_parse_mock.call_args_list])
 
 
-class TestMain(object):
+class TestMain:
 
     def test_argument_passed_through(self, mocker):
         runner = CliRunner()

--- a/tests/test_jjb_subcommand.py
+++ b/tests/test_jjb_subcommand.py
@@ -14,7 +14,7 @@
 from jenkins_job_linter.jjb_subcommand import LintSubCommand
 
 
-class TestParseArgs(object):
+class TestParseArgs:
 
     def test_parser_named_lint(self, mocker):
         subcommand = LintSubCommand()
@@ -41,7 +41,7 @@ class TestParseArgs(object):
                 subparser_mock.add_parser.return_value) == mock.call_args
 
 
-class TestExecute(object):
+class TestExecute:
 
     def test_arguments_passed_through(self, mocker):
         super_execute_mock = mocker.patch(

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -27,7 +27,7 @@ FAILING_SHEBANG_ARGS = ['e', 'u', 'x'] + list(itertools.combinations('eux', 2))
 PASSING_SHEBANG_ARGS = itertools.permutations('eux')
 
 
-class ShellTest(object):
+class ShellTest:
 
     _xml_template = '''\
         <project>
@@ -99,7 +99,7 @@ class TestCheckForEmptyShell(ShellTest):
         assert result is expected
 
 
-class TestEnsureTimestamps(object):
+class TestEnsureTimestamps:
 
     @pytest.mark.parametrize('expected,xml_string', (
         (False, '<project/>'),
@@ -115,7 +115,7 @@ class TestEnsureTimestamps(object):
         assert result is expected
 
 
-class TestLinter(object):
+class TestLinter:
 
     class LintTestSubclass(Linter):
 


### PR DESCRIPTION
We don't need it in Python 3.