### PR TITLE
Run integration tests against JJB trunk in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python: 3.6
 env:
  - TOX_ENV=codecov
  - TOX_ENV=integration_tests
+ - TOX_ENV=integration_tests_with_jjb_trunk
  - TOX_ENV=py36
  - TOX_ENV=lint
  - TOX_ENV=mypy

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,13 @@ commands=
 commands=
     pytest -n4 --cov=jenkins_job_linter --cov-fail-under=100 --cov-report term-missing integration_tests/tests.py
 
+[testenv:integration_tests_with_jjb_trunk]
+deps=
+    -rtest-requirements.txt
+    git+https://git.openstack.org/openstack-infra/jenkins-job-builder#egg=jenkins-job-builder
+commands=
+    pytest -n4 --cov=jenkins_job_linter --cov-fail-under=100 --cov-report term-missing integration_tests/tests.py
+
 [testenv:lint]
 deps=
     flake8


### PR DESCRIPTION
This uses a new tox target, so it can also be run locally easily.  It
isn't part of the default tox run, as it's time-consuming and errors are
unlikely to be caused by changes in JJL.

Fixes #43.