### PR TITLE
Remove build spam when running `jenkins-job lint`

### DIFF
--- a/integration_tests/tests.py
+++ b/integration_tests/tests.py
@@ -52,8 +52,10 @@ def _direct_runner(tmpdir, config):
         config_args = ['--conf', str(conf_file)]
     success = True
     try:
-        output = subprocess.check_output(['jenkins-job-linter', output_dir]
-                                         + config_args)
+        output = subprocess.check_output(
+            ['jenkins-job-linter', output_dir] + config_args,
+            stderr=subprocess.STDOUT,
+        )
     except subprocess.CalledProcessError as exc:
         output = exc.output
         success = False
@@ -68,7 +70,9 @@ def _jjb_subcommand_runner(tmpdir, config):
     try:
         output = subprocess.check_output([
             'jenkins-jobs', '--conf', str(conf_file),
-            'lint', os.path.join(tmpdir)])
+            'lint', os.path.join(tmpdir)],
+            stderr=subprocess.STDOUT,
+        )
     except subprocess.CalledProcessError as exc:
         output = exc.output
         success = False

--- a/jenkins_job_linter/jjb_subcommand.py
+++ b/jenkins_job_linter/jjb_subcommand.py
@@ -35,6 +35,7 @@ class LintSubCommand(test.TestSubCommand):
 
     def parse_args(self, subparser: argparse._SubParsersAction) -> None:
         """Create a lint subparser and add the necessary options."""
+        logging.getLogger('jenkins_jobs').setLevel(logging.CRITICAL)
         lint = subparser.add_parser('lint')
 
         self.parse_option_recursive_exclude(lint)


### PR DESCRIPTION
This fixes #45.