### PR TITLE
Set empty columns for the empty column test

### DIFF
--- a/integration_tests/test_views.yaml
+++ b/integration_tests/test_views.yaml
@@ -28,6 +28,7 @@ cases:
           - view:
               name: test-view
               view-type: list
+              columns: []
       expected_output: |
           test-view: checking column configuration: FAIL: No columns configured
       expect_success: False


### PR DESCRIPTION
The JJB default has changed, so it no longer fails.