### PR TITLE
Get full output from tests when run through tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,18 +5,18 @@ envlist=mypy,py35,py36,integration_tests,lint,docs
 deps=
     -rtest-requirements.txt
 commands=
-    pytest --cov=jenkins_job_linter --cov-fail-under=100 --cov-report term-missing
+    pytest -vv --cov=jenkins_job_linter --cov-fail-under=100 --cov-report term-missing
 
 [testenv:integration_tests]
 commands=
-    pytest -n4 --cov=jenkins_job_linter --cov-fail-under=100 --cov-report term-missing integration_tests/tests.py
+    pytest -vv -n4 --cov=jenkins_job_linter --cov-fail-under=100 --cov-report term-missing integration_tests/tests.py
 
 [testenv:integration_tests_with_jjb_trunk]
 deps=
     -rtest-requirements.txt
     git+https://git.openstack.org/openstack-infra/jenkins-job-builder#egg=jenkins-job-builder
 commands=
-    pytest -n4 --cov=jenkins_job_linter --cov-fail-under=100 --cov-report term-missing integration_tests/tests.py
+    pytest -vv -n4 --cov=jenkins_job_linter --cov-fail-under=100 --cov-report term-missing integration_tests/tests.py
 
 [testenv:lint]
 deps=


### PR DESCRIPTION
We can't necessarily reproduce errors there, so get as much info as
possible.